### PR TITLE
fix thrift header not parsed when receiving

### DIFF
--- a/tests/basic/index.js
+++ b/tests/basic/index.js
@@ -142,3 +142,11 @@ tests.push(client => {
     done('i64 response self');
   });
 });
+
+tests.push(client => {
+  const request_id = "thrift.cilent^^7323271402587046920|1514095637304"
+  return client.call('etrace_thrift_header', {}, { request_id }).then(result => {
+    assert.deepEqual(result, request_id);
+    done('etrace_thrift_header response request_id');
+  });
+});

--- a/tests/basic/mock-server.js
+++ b/tests/basic/mock-server.js
@@ -31,6 +31,8 @@ server.register('zero', ctx => ctx);
 
 server.register('i64', ctx => ctx);
 
+server.register('etrace_thrift_header', ctx => ctx.__header.request_id);
+
 {
   let hehe = 0;
   server.register('oneway_set_hehe', ctx => hehe = ctx.hehe);

--- a/tests/basic/test.thrift
+++ b/tests/basic/test.thrift
@@ -55,4 +55,6 @@ service Test {
 
   I64Data i64(1: i64 data);
 
+  string etrace_thrift_header();
+
 }

--- a/thrift-client.js
+++ b/thrift-client.js
@@ -53,7 +53,7 @@ class ThriftServerListener extends EventEmitter {
 }
 
 
-let tcReceive = (that, { id, type, name, fields }) => {
+let tcReceive = (that, { id, type, name, fields, header }) => {
   let api = that.schema.service[name];
   switch (type) {
     case 'CALL':
@@ -61,6 +61,7 @@ let tcReceive = (that, { id, type, name, fields }) => {
         new Promise((resolve, reject) => {
           try {
             let params = that.schema.decodeStruct(api.args, { fields });
+            if (header) params.__header = Header.decode(header);
             resolve(that.trigger(name, params));
           } catch (error) {
             reject(error);


### PR DESCRIPTION
fix thrift header not parsed when receiving by adding `__header` to context